### PR TITLE
[auth] 추가 정보 회원가입 API

### DIFF
--- a/src/main/java/gogo/gogouser/domain/auth/application/AuthService.kt
+++ b/src/main/java/gogo/gogouser/domain/auth/application/AuthService.kt
@@ -1,9 +1,11 @@
 package gogo.gogouser.domain.auth.application
 
 import gogo.gogouser.domain.auth.application.dto.AuthLoginReqDto
+import gogo.gogouser.domain.auth.application.dto.AuthSignUpReqDto
 import gogo.gogouser.domain.auth.application.dto.AuthTokenDto
 
 interface AuthService {
     fun login(dto: AuthLoginReqDto): AuthTokenDto
     fun refresh(token: String): AuthTokenDto
+    fun signup(dto: AuthSignUpReqDto)
 }

--- a/src/main/java/gogo/gogouser/domain/auth/application/AuthServiceImpl.kt
+++ b/src/main/java/gogo/gogouser/domain/auth/application/AuthServiceImpl.kt
@@ -1,24 +1,34 @@
 package gogo.gogouser.domain.auth.application
 
 import gogo.gogouser.domain.auth.application.dto.AuthLoginReqDto
+import gogo.gogouser.domain.auth.application.dto.AuthSignUpReqDto
 import gogo.gogouser.domain.auth.application.dto.AuthTokenDto
+import gogo.gogouser.domain.school.root.application.SchoolProcessor
+import gogo.gogouser.domain.school.root.persistence.SchoolRepository
+import gogo.gogouser.domain.student.persistence.Student
+import gogo.gogouser.domain.student.persistence.StudentRepository
 import gogo.gogouser.domain.user.application.UserProcessor
 import gogo.gogouser.domain.user.application.UserReader
 import gogo.gogouser.domain.user.persistence.User
 import gogo.gogouser.global.external.GoogleLoginFeignClientService
 import gogo.gogouser.global.jwt.JwtGenerator
+import gogo.gogouser.global.util.UserUtil
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class AuthServiceImpl(
+    private val userUtil: UserUtil,
     private val authReader: AuthReader,
     private val authProcessor: AuthProcessor,
     private val userMapper: AuthMapper,
     private val userProcessor: UserProcessor,
+    private val schoolProcessor: SchoolProcessor,
     private val jwtGenerator: JwtGenerator,
     private val oauthService: GoogleLoginFeignClientService,
-    private val userReader: UserReader
+    private val userReader: UserReader,
+    private val schoolRepository: SchoolRepository,
+    private val studentRepository: StudentRepository
 ) : AuthService {
 
     @Transactional
@@ -33,6 +43,15 @@ class AuthServiceImpl(
         val refreshToken = authReader.read(token)
         val user = userReader.read(refreshToken.userId)
         return generateToken(user)
+    }
+
+    @Transactional
+    override fun signup(dto: AuthSignUpReqDto) {
+        val user = userUtil.getCurrentUser()
+        val school = schoolProcessor.getSchoolOrCreate(dto)
+        val student = Student.of(user, school, dto)
+        studentRepository.save(student)
+        userProcessor.signUp(user, dto)
     }
 
     private fun generateToken(user: User): AuthTokenDto {

--- a/src/main/java/gogo/gogouser/domain/auth/application/dto/AuthDto.kt
+++ b/src/main/java/gogo/gogouser/domain/auth/application/dto/AuthDto.kt
@@ -1,11 +1,45 @@
 package gogo.gogouser.domain.auth.application.dto
 
+import gogo.gogouser.domain.school.root.persistence.SchoolType
+import gogo.gogouser.domain.user.persistence.Sex
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 
 data class AuthLoginReqDto(
     @NotBlank
     val oauthToken: String,
     val deviceToken: String?
+)
+
+data class AuthSignUpReqDto(
+    val deviceToken: String?,
+    @NotBlank
+    val name: String,
+    @NotNull
+    val classNumber: Int,
+    @NotNull
+    val studentNumber: Int,
+    @NotNull
+    val sex: Sex,
+    @NotNull
+    val school: SchoolInfoDto
+)
+
+data class SchoolInfoDto(
+    @NotBlank
+    val sdCode: String,
+    @NotBlank
+    val name: String,
+    @NotNull
+    val type: SchoolType,
+    @NotBlank
+    val address: String,
+    @NotBlank
+    val region: String,
+    @NotNull
+    val countOfStudent: Int,
+    @NotNull
+    val phoneNumber: String,
 )
 
 data class AuthTokenDto(

--- a/src/main/java/gogo/gogouser/domain/auth/presentation/AuthController.kt
+++ b/src/main/java/gogo/gogouser/domain/auth/presentation/AuthController.kt
@@ -2,6 +2,7 @@ package gogo.gogouser.domain.auth.presentation
 
 import gogo.gogouser.domain.auth.application.AuthService
 import gogo.gogouser.domain.auth.application.dto.AuthLoginReqDto
+import gogo.gogouser.domain.auth.application.dto.AuthSignUpReqDto
 import gogo.gogouser.domain.auth.application.dto.AuthTokenDto
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
@@ -27,6 +28,14 @@ class AuthController(
     ): ResponseEntity<AuthTokenDto> {
         val response = authService.refresh(token)
         return ResponseEntity.ok(response)
+    }
+
+    @PostMapping("/signup")
+    fun signup(
+        @RequestBody @Valid dto: AuthSignUpReqDto
+    ): ResponseEntity<Void> {
+        authService.signup(dto)
+        return ResponseEntity.ok().build()
     }
 
 }

--- a/src/main/java/gogo/gogouser/domain/school/detail/persistence/SchoolDetail.kt
+++ b/src/main/java/gogo/gogouser/domain/school/detail/persistence/SchoolDetail.kt
@@ -1,5 +1,6 @@
 package gogo.gogouser.domain.school.detail.persistence
 
+import gogo.gogouser.domain.auth.application.dto.SchoolInfoDto
 import gogo.gogouser.domain.school.root.persistence.School
 import jakarta.persistence.*
 
@@ -27,4 +28,18 @@ class SchoolDetail(
     @Column(name = "phoneNumber", nullable = false)
     val phoneNumber: String,
 ) {
+
+    companion object {
+
+        fun of (school: School, dto: SchoolInfoDto) =
+            SchoolDetail(
+                school = school,
+                address = dto.address,
+                countOfStudent = dto.countOfStudent,
+                region = dto.region,
+                phoneNumber = dto.phoneNumber,
+            )
+
+    }
+
 }

--- a/src/main/java/gogo/gogouser/domain/school/root/application/SchoolProcessor.kt
+++ b/src/main/java/gogo/gogouser/domain/school/root/application/SchoolProcessor.kt
@@ -1,0 +1,27 @@
+package gogo.gogouser.domain.school.root.application
+
+import gogo.gogouser.domain.auth.application.dto.AuthSignUpReqDto
+import gogo.gogouser.domain.school.detail.persistence.SchoolDetail
+import gogo.gogouser.domain.school.detail.persistence.SchoolDetailRepository
+import gogo.gogouser.domain.school.root.persistence.School
+import gogo.gogouser.domain.school.root.persistence.SchoolRepository
+import org.springframework.stereotype.Component
+
+@Component
+class SchoolProcessor(
+    private val schoolReader: SchoolReader,
+    private val schoolRepository: SchoolRepository,
+    private val schoolDetailRepository: SchoolDetailRepository
+) {
+
+    fun getSchoolOrCreate(dto: AuthSignUpReqDto): School =
+        schoolReader.readBySdCodeOrNull(dto.school.sdCode)
+            ?: run {
+                val createSchool = School.of(dto.school)
+                val savedSchool = schoolRepository.save(createSchool)
+                val schoolDetail = SchoolDetail.of(createSchool, dto.school)
+                schoolDetailRepository.save(schoolDetail)
+                savedSchool
+            }
+
+}

--- a/src/main/java/gogo/gogouser/domain/school/root/application/SchoolReader.kt
+++ b/src/main/java/gogo/gogouser/domain/school/root/application/SchoolReader.kt
@@ -1,0 +1,14 @@
+package gogo.gogouser.domain.school.root.application
+
+import gogo.gogouser.domain.school.root.persistence.School
+import gogo.gogouser.domain.school.root.persistence.SchoolRepository
+import org.springframework.stereotype.Component
+
+@Component
+class SchoolReader(
+    private val schoolRepository: SchoolRepository
+) {
+
+    fun readBySdCodeOrNull(sdCode: String): School? = schoolRepository.findBySdCode(sdCode)
+
+}

--- a/src/main/java/gogo/gogouser/domain/school/root/persistence/School.kt
+++ b/src/main/java/gogo/gogouser/domain/school/root/persistence/School.kt
@@ -1,5 +1,7 @@
 package gogo.gogouser.domain.school.root.persistence
 
+import gogo.gogouser.domain.auth.application.dto.SchoolInfoDto
+import gogo.gogouser.domain.school.detail.persistence.SchoolDetail
 import jakarta.persistence.*
 
 @Entity
@@ -10,13 +12,32 @@ class School(
     @Column(name = "id")
     val id: Long = 0,
 
+    @Column(name = "sd_code", unique = true, nullable = false)
+    val sdCode: String,
+
     @Column(name = "school_name", nullable = false)
     val schoolName: String,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "school_type", nullable = false)
-    val schoolType: SchoolType
+    val schoolType: SchoolType,
+
+    @OneToOne(cascade = [(CascadeType.ALL)], mappedBy = "school")
+    @JoinColumn(name = "school_detail_id")
+    val schoolDetail: SchoolDetail? = null,
 ) {
+
+    companion object {
+
+        fun of(dto: SchoolInfoDto)=
+            School(
+                sdCode = dto.sdCode,
+                schoolName = dto.name,
+                schoolType = dto.type,
+            )
+
+    }
+
 }
 
 enum class SchoolType {

--- a/src/main/java/gogo/gogouser/domain/school/root/persistence/SchoolRepository.kt
+++ b/src/main/java/gogo/gogouser/domain/school/root/persistence/SchoolRepository.kt
@@ -3,4 +3,5 @@ package gogo.gogouser.domain.school.root.persistence
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface SchoolRepository: JpaRepository<School, Long> {
+    fun findBySdCode(sdCode: String): School?
 }

--- a/src/main/java/gogo/gogouser/domain/student/persistence/Student.kt
+++ b/src/main/java/gogo/gogouser/domain/student/persistence/Student.kt
@@ -1,5 +1,6 @@
 package gogo.gogouser.domain.student.persistence
 
+import gogo.gogouser.domain.auth.application.dto.AuthSignUpReqDto
 import gogo.gogouser.domain.school.root.persistence.School
 import gogo.gogouser.domain.user.persistence.User
 import jakarta.persistence.*
@@ -32,4 +33,16 @@ class Student(
     @Column(name = "is_active_profanity_filter", nullable = false)
     val isActiveProfanityFilter: Boolean = false,
 ) {
+    companion object {
+
+        fun of(user: User, school: School, dto: AuthSignUpReqDto) =
+            Student(
+                user = user,
+                school = school,
+                deviceToken = dto.deviceToken,
+                classNumber = dto.classNumber,
+                studentNumber = dto.studentNumber,
+            )
+
+    }
 }

--- a/src/main/java/gogo/gogouser/domain/user/application/UserProcessor.kt
+++ b/src/main/java/gogo/gogouser/domain/user/application/UserProcessor.kt
@@ -1,5 +1,6 @@
 package gogo.gogouser.domain.user.application
 
+import gogo.gogouser.domain.auth.application.dto.AuthSignUpReqDto
 import gogo.gogouser.domain.user.persistence.User
 import gogo.gogouser.domain.user.persistence.UserRepository
 import org.springframework.stereotype.Component
@@ -13,5 +14,10 @@ class UserProcessor(
     fun getUserOrCreate(email: String): User =
         userReader.readByEmailOrNull(email)
             ?: userRepository.save(User.of(email))
+
+    fun signUp(user: User, dto: AuthSignUpReqDto) {
+        user.signUp(dto)
+        userRepository.save(user)
+    }
 
 }

--- a/src/main/java/gogo/gogouser/domain/user/persistence/User.kt
+++ b/src/main/java/gogo/gogouser/domain/user/persistence/User.kt
@@ -1,5 +1,6 @@
 package gogo.gogouser.domain.user.persistence
 
+import gogo.gogouser.domain.auth.application.dto.AuthSignUpReqDto
 import jakarta.persistence.*
 import java.time.LocalDateTime
 
@@ -15,25 +16,28 @@ class User(
     val email: String,
 
     @Column(name = "name", nullable = true)
-    val name: String? = null,
-
-    @Column(name = "student_number", nullable = true)
-    val studentNumber: Int? = null,
+    var name: String? = null,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "sex", nullable = true)
-    val sex: Sex? = null,
+    var sex: Sex? = null,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "authority", nullable = false)
-    val authority: Authority = Authority.UNAUTHENTICATED,
+    var authority: Authority = Authority.UNAUTHENTICATED,
 
     @Column(name = "is_suspended", nullable = false)
-    val isSuspended: Boolean = false,
+    var isSuspended: Boolean = false,
 
     @Column(name = "created_at", nullable = false)
     val createdAt: LocalDateTime = LocalDateTime.now(),
 ) {
+
+    fun signUp(dto: AuthSignUpReqDto) {
+        name = dto.name
+        sex = dto.sex
+        authority = Authority.USER
+    }
 
     companion object {
         fun of(email: String) = User(email = email)

--- a/src/main/java/gogo/gogouser/global/security/SecurityConfig.kt
+++ b/src/main/java/gogo/gogouser/global/security/SecurityConfig.kt
@@ -1,6 +1,7 @@
 package gogo.gogouser.global.security
 
 import gogo.gogouser.domain.auth.application.AuthReader
+import gogo.gogouser.domain.user.persistence.Authority
 import gogo.gogouser.global.filter.AuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -48,6 +49,7 @@ class SecurityConfig(
                 // auth
                 .requestMatchers(HttpMethod.POST, "/user/auth/login").permitAll()
                 .requestMatchers(HttpMethod.POST, "/user/auth/refresh").permitAll()
+                .requestMatchers(HttpMethod.POST, "/user/auth/signup").hasAuthority(Authority.UNAUTHENTICATED.name)
 
                 // server to server
                 .requestMatchers(HttpMethod.GET, "/user/student").permitAll()


### PR DESCRIPTION
## 개요
- oauth 로그인 이후 추가정보 회원가입 API를 개발하였습니다. (`/user/auth/signup`)

## 본문
- `UNAUTHENTICATED` 권한인 유저(oauth 로그인 이후)만 요청 가능합니다.
- 회원가입 이후 `UNAUTHENTICATED`에서 `USER` 권한으로 업데이트 됩니다.