### PR TITLE
[student] 학생ID들로 학생 정보 일괄 조회 API

### DIFF
--- a/src/main/java/gogo/gogouser/domain/student/application/StudentMapper.kt
+++ b/src/main/java/gogo/gogouser/domain/student/application/StudentMapper.kt
@@ -1,5 +1,6 @@
 package gogo.gogouser.domain.student.application
 
+import gogo.gogouser.domain.student.application.dto.StudentBundleDto
 import gogo.gogouser.domain.student.application.dto.StudentDto
 import gogo.gogouser.domain.student.application.dto.StudentInfoDto
 import gogo.gogouser.domain.student.persistence.Student
@@ -28,15 +29,17 @@ class StudentMapper {
     }
 
     fun mapStudents(students: List<Student>) =
-        students.map {
-            StudentInfoDto(
-                studentId = it.id,
-                schoolId = it.school.id,
-                sex = it.user.sex!!,
-                name = it.user.name!!,
-                deviceToken = it.deviceToken,
-                classNumber = it.classNumber,
-                studentNumber = it.studentNumber,
-            )
-        }
+        StudentBundleDto (
+            students = students.map {
+                StudentInfoDto(
+                    studentId = it.id,
+                    schoolId = it.school.id,
+                    sex = it.user.sex!!,
+                    name = it.user.name!!,
+                    deviceToken = it.deviceToken,
+                    classNumber = it.classNumber,
+                    studentNumber = it.studentNumber,
+                )
+            }
+        )
 }

--- a/src/main/java/gogo/gogouser/domain/student/application/StudentMapper.kt
+++ b/src/main/java/gogo/gogouser/domain/student/application/StudentMapper.kt
@@ -1,6 +1,7 @@
 package gogo.gogouser.domain.student.application
 
 import gogo.gogouser.domain.student.application.dto.StudentDto
+import gogo.gogouser.domain.student.application.dto.StudentInfoDto
 import gogo.gogouser.domain.student.persistence.Student
 import org.springframework.stereotype.Component
 
@@ -25,4 +26,17 @@ class StudentMapper {
             createdAt = user.createdAt
         )
     }
+
+    fun mapStudents(students: List<Student>) =
+        students.map {
+            StudentInfoDto(
+                studentId = it.id,
+                schoolId = it.school.id,
+                sex = it.user.sex!!,
+                name = it.user.name!!,
+                deviceToken = it.deviceToken,
+                classNumber = it.classNumber,
+                studentNumber = it.studentNumber,
+            )
+        }
 }

--- a/src/main/java/gogo/gogouser/domain/student/application/StudentReader.kt
+++ b/src/main/java/gogo/gogouser/domain/student/application/StudentReader.kt
@@ -15,4 +15,6 @@ class StudentReader(
         studentRepository.findByUserId(userId)
             ?: throw UserException("Not Found Student user id = $userId", HttpStatus.NOT_FOUND.value())
 
+    fun readByIds(studentIds: List<Long>): List<Student> = studentRepository.findByIds(studentIds)
+
 }

--- a/src/main/java/gogo/gogouser/domain/student/application/StudentService.kt
+++ b/src/main/java/gogo/gogouser/domain/student/application/StudentService.kt
@@ -1,7 +1,9 @@
 package gogo.gogouser.domain.student.application
 
 import gogo.gogouser.domain.student.application.dto.StudentDto
+import gogo.gogouser.domain.student.application.dto.StudentInfoDto
 
 interface StudentService {
     fun queryByUserId(userId: Long): StudentDto
+    fun queryBundle(studentIds: List<Long>): List<StudentInfoDto>
 }

--- a/src/main/java/gogo/gogouser/domain/student/application/StudentService.kt
+++ b/src/main/java/gogo/gogouser/domain/student/application/StudentService.kt
@@ -1,9 +1,9 @@
 package gogo.gogouser.domain.student.application
 
+import gogo.gogouser.domain.student.application.dto.StudentBundleDto
 import gogo.gogouser.domain.student.application.dto.StudentDto
-import gogo.gogouser.domain.student.application.dto.StudentInfoDto
 
 interface StudentService {
     fun queryByUserId(userId: Long): StudentDto
-    fun queryBundle(studentIds: List<Long>): List<StudentInfoDto>
+    fun queryBundle(studentIds: List<Long>): StudentBundleDto
 }

--- a/src/main/java/gogo/gogouser/domain/student/application/StudentServiceImpl.kt
+++ b/src/main/java/gogo/gogouser/domain/student/application/StudentServiceImpl.kt
@@ -1,6 +1,7 @@
 package gogo.gogouser.domain.student.application
 
 import gogo.gogouser.domain.student.application.dto.StudentDto
+import gogo.gogouser.domain.student.application.dto.StudentInfoDto
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -14,6 +15,12 @@ class StudentServiceImpl(
     override fun queryByUserId(userId: Long): StudentDto {
         val student = studentReader.readByUserId(userId)
         return studentMapper.map(student)
+    }
+
+    @Transactional(readOnly = true)
+    override fun queryBundle(studentIds: List<Long>): List<StudentInfoDto> {
+        val students = studentReader.readByIds(studentIds)
+        return studentMapper.mapStudents(students)
     }
 
 }

--- a/src/main/java/gogo/gogouser/domain/student/application/StudentServiceImpl.kt
+++ b/src/main/java/gogo/gogouser/domain/student/application/StudentServiceImpl.kt
@@ -1,5 +1,6 @@
 package gogo.gogouser.domain.student.application
 
+import gogo.gogouser.domain.student.application.dto.StudentBundleDto
 import gogo.gogouser.domain.student.application.dto.StudentDto
 import gogo.gogouser.domain.student.application.dto.StudentInfoDto
 import org.springframework.stereotype.Service
@@ -18,7 +19,7 @@ class StudentServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun queryBundle(studentIds: List<Long>): List<StudentInfoDto> {
+    override fun queryBundle(studentIds: List<Long>): StudentBundleDto {
         val students = studentReader.readByIds(studentIds)
         return studentMapper.mapStudents(students)
     }

--- a/src/main/java/gogo/gogouser/domain/student/application/dto/StudentDto.kt
+++ b/src/main/java/gogo/gogouser/domain/student/application/dto/StudentDto.kt
@@ -16,3 +16,13 @@ data class StudentDto(
     val isActiveProfanityFilter: Boolean,
     val createdAt: LocalDateTime
 )
+
+data class StudentInfoDto(
+    val studentId: Long,
+    val schoolId: Long,
+    val sex: Sex,
+    val name: String,
+    val deviceToken: String?,
+    val classNumber: Int,
+    val studentNumber: Int,
+)

--- a/src/main/java/gogo/gogouser/domain/student/application/dto/StudentDto.kt
+++ b/src/main/java/gogo/gogouser/domain/student/application/dto/StudentDto.kt
@@ -17,6 +17,10 @@ data class StudentDto(
     val createdAt: LocalDateTime
 )
 
+data class StudentBundleDto(
+    val students: List<StudentInfoDto>
+)
+
 data class StudentInfoDto(
     val studentId: Long,
     val schoolId: Long,

--- a/src/main/java/gogo/gogouser/domain/student/persistence/StudentRepository.kt
+++ b/src/main/java/gogo/gogouser/domain/student/persistence/StudentRepository.kt
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.Query
 interface StudentRepository: JpaRepository<Student, Long> {
     fun findByUserId(userId: Long): Student?
 
-    @Query("SELECT s FROM Student s WHERE s.id in (:id)")
+    @Query("SELECT s FROM Student s WHERE s.id in (:ids)")
     fun findByIds(ids: List<Long>): List<Student>
 }

--- a/src/main/java/gogo/gogouser/domain/student/persistence/StudentRepository.kt
+++ b/src/main/java/gogo/gogouser/domain/student/persistence/StudentRepository.kt
@@ -1,7 +1,11 @@
 package gogo.gogouser.domain.student.persistence
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface StudentRepository: JpaRepository<Student, Long> {
     fun findByUserId(userId: Long): Student?
+
+    @Query("SELECT s FROM Student s WHERE s.id in (:id)")
+    fun findByIds(ids: List<Long>): List<Student>
 }

--- a/src/main/java/gogo/gogouser/domain/student/presentation/StudentController.kt
+++ b/src/main/java/gogo/gogouser/domain/student/presentation/StudentController.kt
@@ -1,6 +1,7 @@
 package gogo.gogouser.domain.student.presentation
 
 import gogo.gogouser.domain.student.application.StudentService
+import gogo.gogouser.domain.student.application.dto.StudentBundleDto
 import gogo.gogouser.domain.student.application.dto.StudentDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -19,6 +20,14 @@ class StudentController(
         @RequestParam("userId") userId: Long
     ): ResponseEntity<StudentDto> {
         val response = studentService.queryByUserId(userId)
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/student/bundle")
+    fun queryBundle(
+        @RequestParam("studentIds") studentIs: List<Long>
+    ): ResponseEntity<StudentBundleDto> {
+        val response = studentService.queryBundle(studentIs)
         return ResponseEntity.ok(response)
     }
 

--- a/src/main/java/gogo/gogouser/global/security/SecurityConfig.kt
+++ b/src/main/java/gogo/gogouser/global/security/SecurityConfig.kt
@@ -53,6 +53,7 @@ class SecurityConfig(
 
                 // server to server
                 .requestMatchers(HttpMethod.GET, "/user/student").permitAll()
+                .requestMatchers(HttpMethod.GET, "/user/student/bundle").permitAll()
 
                 // test
                 .requestMatchers(HttpMethod.POST, "/user/auth/test-login/{user_id}").permitAll()


### PR DESCRIPTION
## 개요
학생 ID들로 학생 정보 일괄 조회 server to server API를 개발하였습니다.

## 본문
다른 서비스에서 학생들의 정보를 일괄로 조회해야하는 일이 빈번하게 있습니다. (커뮤니티 검색, 추후 개발될 푸시알림 일괄 전송 등) 해당 기능을 구현할 때 한번의 요청으로 여러 학생 정보를 일괄로 조회할 수 있도록 합니다.