### PR TITLE
[global] server to server API securit url IP 필터링

### DIFF
--- a/src/main/java/gogo/gogouser/domain/auth/application/AuthService.kt
+++ b/src/main/java/gogo/gogouser/domain/auth/application/AuthService.kt
@@ -8,5 +8,5 @@ import gogo.gogouser.domain.auth.application.dto.AuthTokenDto
 interface AuthService {
     fun login(dto: AuthLoginReqDto): AuthLoginDto
     fun refresh(token: String): AuthTokenDto
-    fun signup(dto: AuthSignUpReqDto)
+    fun signup(dto: AuthSignUpReqDto): AuthTokenDto
 }

--- a/src/main/java/gogo/gogouser/domain/auth/application/AuthServiceImpl.kt
+++ b/src/main/java/gogo/gogouser/domain/auth/application/AuthServiceImpl.kt
@@ -50,13 +50,14 @@ class AuthServiceImpl(
     }
 
     @Transactional
-    override fun signup(dto: AuthSignUpReqDto) {
+    override fun signup(dto: AuthSignUpReqDto): AuthTokenDto {
         val user = userUtil.getCurrentUser()
         val school = schoolProcessor.getSchoolOrCreate(dto)
         studentValidator.validDuplicate(school.id, dto.grade, dto.classNumber, dto.studentNumber)
         val student = Student.of(user, school, dto)
         studentRepository.save(student)
-        userProcessor.signUp(user, dto)
+        val signedUser = userProcessor.signUp(user, dto)
+        return generateToken(signedUser)
     }
 
     private fun generateToken(user: User): AuthTokenDto {

--- a/src/main/java/gogo/gogouser/domain/auth/presentation/AuthController.kt
+++ b/src/main/java/gogo/gogouser/domain/auth/presentation/AuthController.kt
@@ -37,9 +37,9 @@ class AuthController(
     @PostMapping("/signup")
     fun signup(
         @RequestBody @Valid dto: AuthSignUpReqDto
-    ): ResponseEntity<Void> {
-        authService.signup(dto)
-        return ResponseEntity.ok().build()
+    ): ResponseEntity<AuthTokenDto> {
+        val response = authService.signup(dto)
+        return ResponseEntity.ok(response)
     }
 
 }

--- a/src/main/java/gogo/gogouser/domain/auth/presentation/AuthController.kt
+++ b/src/main/java/gogo/gogouser/domain/auth/presentation/AuthController.kt
@@ -18,11 +18,6 @@ class AuthController(
     private val jwtGenerator: JwtGenerator,
 ) {
 
-    @PostMapping("/test-login/{user_id}")
-    fun test(
-        @PathVariable("user_id") userId: Long,
-    ) = jwtGenerator.generateToken(userId.toString(), Authority.USER)
-
     @PostMapping("/login")
     fun login(
         @RequestBody @Valid dto: AuthLoginReqDto

--- a/src/main/java/gogo/gogouser/domain/user/application/UserProcessor.kt
+++ b/src/main/java/gogo/gogouser/domain/user/application/UserProcessor.kt
@@ -15,9 +15,9 @@ class UserProcessor(
         userReader.readByEmailOrNull(email)
             ?: userRepository.save(User.of(email))
 
-    fun signUp(user: User, dto: AuthSignUpReqDto) {
+    fun signUp(user: User, dto: AuthSignUpReqDto): User {
         user.signUp(dto)
-        userRepository.save(user)
+        return userRepository.save(user)
     }
 
 }

--- a/src/main/java/gogo/gogouser/global/config/PropertiesScanConfig.kt
+++ b/src/main/java/gogo/gogouser/global/config/PropertiesScanConfig.kt
@@ -1,13 +1,15 @@
 package gogo.gogouser.global.config
 
 import gogo.gogouser.global.jwt.JwtProperties
+import gogo.gogouser.global.security.SecurityProperties
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 @ConfigurationPropertiesScan(
     basePackageClasses = [
-        JwtProperties::class
+        JwtProperties::class,
+        SecurityProperties::class
     ]
 )
 class PropertiesScanConfig {

--- a/src/main/java/gogo/gogouser/global/security/SecurityConfig.kt
+++ b/src/main/java/gogo/gogouser/global/security/SecurityConfig.kt
@@ -7,21 +7,28 @@ import gogo.gogouser.global.filter.LoggingFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
+import org.springframework.security.authorization.AuthorizationDecision
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.core.Authentication
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.security.web.util.matcher.IpAddressMatcher
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+import java.util.function.Supplier
+
 
 @Configuration
 class SecurityConfig(
     private val customAccessDeniedHandler: CustomAccessDeniedHandler,
     private val customAuthenticationEntryPointHandler: CustomAuthenticationEntryPointHandler,
     private val authenticationFilter: AuthenticationFilter,
-    private val loggingFilter: LoggingFilter
+    private val loggingFilter: LoggingFilter,
+    private val securityProperties: SecurityProperties,
 ) {
 
     @Bean
@@ -61,16 +68,18 @@ class SecurityConfig(
                 .requestMatchers(HttpMethod.PATCH, "/user/student/me").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
 
                 // server to server
-                .requestMatchers(HttpMethod.GET, "/user/student").permitAll()
-                .requestMatchers(HttpMethod.GET, "/user/student/bundle").permitAll()
-
-                // test
-                .requestMatchers(HttpMethod.POST, "/user/auth/test-login/{user_id}").permitAll()
+                .requestMatchers(HttpMethod.GET, "/user/student").access { _, context -> hasIpAddress(context) }
+                .requestMatchers(HttpMethod.GET, "/user/student/bundle").access { _, context -> hasIpAddress(context) }
 
                 .anyRequest().denyAll()
         }
 
         return http.build()
+    }
+
+    private fun hasIpAddress(context: RequestAuthorizationContext): AuthorizationDecision {
+        val ALLOWED_IP_ADDRESS_MATCHER = IpAddressMatcher("${securityProperties.serverToServerIp}${securityProperties.serverToServerSubnet}")
+        return AuthorizationDecision(ALLOWED_IP_ADDRESS_MATCHER.matches(context.request))
     }
 
     @Bean

--- a/src/main/java/gogo/gogouser/global/security/SecurityProperties.kt
+++ b/src/main/java/gogo/gogouser/global/security/SecurityProperties.kt
@@ -1,0 +1,9 @@
+package gogo.gogouser.global.security
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "security.internal")
+class SecurityProperties(
+    val serverToServerIp: String,
+    val serverToServerSubnet: String,
+)


### PR DESCRIPTION
## 개요
server to server API의 security IP 필터링을 추가하였습니다.

## 본문
- application.yml 설정파일에서 현재 환경에 대한 server to server API의 허용 IP와 서브넷 대역을 받아 security filter에서 필터링합니다.