### PR TITLE
[auth] 회원가입시 JWT 새로 발급 후 반환 처리

### DIFF
--- a/src/main/java/gogo/gogouser/domain/auth/application/AuthService.kt
+++ b/src/main/java/gogo/gogouser/domain/auth/application/AuthService.kt
@@ -8,5 +8,5 @@ import gogo.gogouser.domain.auth.application.dto.AuthTokenDto
 interface AuthService {
     fun login(dto: AuthLoginReqDto): AuthLoginDto
     fun refresh(token: String): AuthTokenDto
-    fun signup(dto: AuthSignUpReqDto)
+    fun signup(dto: AuthSignUpReqDto): AuthTokenDto
 }

--- a/src/main/java/gogo/gogouser/domain/auth/application/AuthServiceImpl.kt
+++ b/src/main/java/gogo/gogouser/domain/auth/application/AuthServiceImpl.kt
@@ -50,13 +50,14 @@ class AuthServiceImpl(
     }
 
     @Transactional
-    override fun signup(dto: AuthSignUpReqDto) {
+    override fun signup(dto: AuthSignUpReqDto): AuthTokenDto {
         val user = userUtil.getCurrentUser()
         val school = schoolProcessor.getSchoolOrCreate(dto)
         studentValidator.validDuplicate(school.id, dto.grade, dto.classNumber, dto.studentNumber)
         val student = Student.of(user, school, dto)
         studentRepository.save(student)
-        userProcessor.signUp(user, dto)
+        val signedUser = userProcessor.signUp(user, dto)
+        return generateToken(signedUser)
     }
 
     private fun generateToken(user: User): AuthTokenDto {

--- a/src/main/java/gogo/gogouser/domain/auth/presentation/AuthController.kt
+++ b/src/main/java/gogo/gogouser/domain/auth/presentation/AuthController.kt
@@ -37,9 +37,9 @@ class AuthController(
     @PostMapping("/signup")
     fun signup(
         @RequestBody @Valid dto: AuthSignUpReqDto
-    ): ResponseEntity<Void> {
-        authService.signup(dto)
-        return ResponseEntity.ok().build()
+    ): ResponseEntity<AuthTokenDto> {
+        val response = authService.signup(dto)
+        return ResponseEntity.ok(response)
     }
 
 }

--- a/src/main/java/gogo/gogouser/domain/user/application/UserProcessor.kt
+++ b/src/main/java/gogo/gogouser/domain/user/application/UserProcessor.kt
@@ -15,9 +15,9 @@ class UserProcessor(
         userReader.readByEmailOrNull(email)
             ?: userRepository.save(User.of(email))
 
-    fun signUp(user: User, dto: AuthSignUpReqDto) {
+    fun signUp(user: User, dto: AuthSignUpReqDto): User {
         user.signUp(dto)
-        userRepository.save(user)
+        return userRepository.save(user)
     }
 
 }


### PR DESCRIPTION
## 개요
회원가입 요청시 업데이트된 권한에 맞는 JWT를 반환하도록 수정하였습니다.

## 본문
- 회원가입시 `UNAUTHENTICATION -> USER `권한으로 변경되지만 기존에 가지고 있던 JWT에는 `UNAUTHENTICATION` 권한이기 때문에 재로그인이 필요한 문제가 발생합니다.
- 해당 문제를 해결하기 위해 회원가입 요청 반환 값으로 업데이트된 JWT를 반환합니다.