### PR TITLE
[user] auth filter 로직 수정

### DIFF
--- a/src/main/java/gogo/gogouser/global/filter/AuthenticationFilter.kt
+++ b/src/main/java/gogo/gogouser/global/filter/AuthenticationFilter.kt
@@ -1,41 +1,43 @@
 package gogo.gogouser.global.filter
 
-import gogo.gogouser.domain.user.persistence.Authority
+import gogo.gogouser.global.security.CustomUserDetailsService
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.AccountStatusUserDetailsChecker
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
-import org.springframework.security.core.Authentication
-import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.core.userdetails.User
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
 @Component
-class AuthenticationFilter : OncePerRequestFilter() {
+class AuthenticationFilter(
+    private val userDetailsService: CustomUserDetailsService
+) : OncePerRequestFilter() {
+
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-        val userId: String? = request.getHeader("Request-User-Id")
-        val authority: Authority? = request.getHeader("Request-User-Authority")?.run { Authority.valueOf(this) }
+        val userId = request.getHeader("Request-User-Id")
 
-        if (userId == null || authority == null) {
+        if (userId == null) {
             filterChain.doFilter(request, response)
             return
         }
 
-        val authorities: MutableCollection<SimpleGrantedAuthority> = ArrayList()
-        authorities.add(SimpleGrantedAuthority("ROLE_${authority.name}"))
-        val userDetails: UserDetails = User(userId, "", authorities)
+        try {
+            val userDetails: UserDetails = userDetailsService.loadUserByUsername(userId)
+            AccountStatusUserDetailsChecker().check(userDetails)
 
-        val authentication: Authentication =
-            UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
-        SecurityContextHolder.getContext().authentication = authentication
+            val authentication = UsernamePasswordAuthenticationToken(userDetails, null, userDetails.authorities)
+            SecurityContextHolder.getContext().authentication = authentication
 
-        filterChain.doFilter(request, response)
+            filterChain.doFilter(request, response)
+        } catch (ex: Exception) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, ex.message ?: "인증 실패")
+        }
     }
 }


### PR DESCRIPTION
## 개요
- user details 객체의 isAccountNonLocked 필드는 AuthenticationManager.authenticate()를 사용할 때만 검사합니다. 하지만 기존 구조에서는 Authentication 객체를 직접 만들어 저장하기 때문에 이를 호출하지 않아 isAccountNonLocked 필드를 검사하지 않습니다.
- userDetailsService 를 직접 호출하여 user 객체를 가져오고 AccountStatusUserDetailsChecker를 직접 호출하여 isAccountNonLocked 필드를 검사하도록 했습니다.