### PR TITLE
[user] 차단된 사용자 검증 추가

### DIFF
--- a/src/main/java/gogo/gogouser/domain/auth/application/AuthServiceImpl.kt
+++ b/src/main/java/gogo/gogouser/domain/auth/application/AuthServiceImpl.kt
@@ -39,6 +39,7 @@ class AuthServiceImpl(
         val email = oauthService.login(dto.oauthToken).email
         authValidator.validGSMLogin(email)
         val user = userProcessor.getUserOrCreate(email)
+        authValidator.validSuspended(user)
         val tokenDto = generateToken(user)
         return authMapper.login(tokenDto, user)
     }
@@ -48,6 +49,7 @@ class AuthServiceImpl(
         val removePrefixToken = token.replace("Bearer ", "").trim()
         val refreshToken = authReader.read(removePrefixToken)
         val user = userReader.read(refreshToken.userId)
+        authValidator.validSuspended(user)
         return generateToken(user)
     }
 

--- a/src/main/java/gogo/gogouser/domain/auth/application/AuthValidator.kt
+++ b/src/main/java/gogo/gogouser/domain/auth/application/AuthValidator.kt
@@ -1,5 +1,6 @@
 package gogo.gogouser.domain.auth.application
 
+import gogo.gogouser.domain.user.persistence.User
 import gogo.gogouser.global.error.UserException
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
@@ -12,6 +13,12 @@ class AuthValidator {
 
         if (!regex.matches(email)) {
             throw UserException("요청한 이메일이 GSM 학생용 이메일이 아닙니다.", HttpStatus.BAD_REQUEST.value())
+        }
+    }
+
+    fun validSuspended(user: User) {
+        if (user.isSuspended) {
+            throw UserException("차단된 사용자입니다.", HttpStatus.FORBIDDEN.value())
         }
     }
 

--- a/src/main/java/gogo/gogouser/domain/student/application/StudentServiceImpl.kt
+++ b/src/main/java/gogo/gogouser/domain/student/application/StudentServiceImpl.kt
@@ -1,9 +1,11 @@
 package gogo.gogouser.domain.student.application
 
+import gogo.gogouser.domain.auth.application.AuthValidator
 import gogo.gogouser.domain.student.application.dto.StudentBundleDto
 import gogo.gogouser.domain.student.application.dto.StudentInfoUpdateDto
 import gogo.gogouser.domain.student.application.dto.StudentSearchDto
 import gogo.gogouser.domain.student.persistence.Student
+import gogo.gogouser.domain.user.application.UserReader
 import gogo.gogouser.global.util.UserUtil
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,11 +16,15 @@ class StudentServiceImpl(
     private val studentMapper: StudentMapper,
     private val userUtil: UserUtil,
     private val studentProcessor: StudentProcessor,
-    private val studentValidator: StudentValidator
+    private val studentValidator: StudentValidator,
+    private val userReader: UserReader,
+    private val authValidator: AuthValidator
 ) : StudentService {
 
     @Transactional(readOnly = true)
     override fun queryByUserId(userId: Long): Student {
+        val user = userReader.read(userId)
+        authValidator.validSuspended(user)
         val student = studentReader.readByUserId(userId)
         return student
     }


### PR DESCRIPTION
## 개요
- 로그인, 토큰 재발급, 학생 정보 조회(internal) API에서 차단된 사용자일시 block 처리하도록 valid 메서드를 추가하였습니다.